### PR TITLE
Consider all authentication subflows during updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- Consider all authentication subflows during updates
+
 ## [5.3.1] - 2022-08-02
 
 ### Added

--- a/src/main/java/de/adorsys/keycloak/config/service/AuthenticationFlowsImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/AuthenticationFlowsImportService.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -173,9 +174,7 @@ public class AuthenticationFlowsImportService {
             RealmImport realmImport,
             AuthenticationFlowRepresentation topLevelFlowToImport
     ) {
-        List<AuthenticationFlowRepresentation> subFlows = AuthenticationFlowUtil.getSubFlowsForTopLevelFlow(
-                realmImport, topLevelFlowToImport
-        );
+        List<AuthenticationFlowRepresentation> subFlows = getAllSubFlows(realmImport, topLevelFlowToImport);
 
         for (AuthenticationFlowRepresentation subFlowToImport : subFlows) {
             if (isSubFlowNotExistingOrHasToBeUpdated(realmImport, topLevelFlowToImport, subFlowToImport)) {
@@ -184,6 +183,20 @@ public class AuthenticationFlowsImportService {
         }
 
         return false;
+    }
+
+    private List<AuthenticationFlowRepresentation> getAllSubFlows(RealmImport realmImport,
+                                                                  AuthenticationFlowRepresentation topLevelFlowToImport) {
+
+        final List<AuthenticationFlowRepresentation> subFlows = AuthenticationFlowUtil.getSubFlowsForTopLevelFlow(
+                realmImport, topLevelFlowToImport);
+        final List<AuthenticationFlowRepresentation> allSubFlows = new ArrayList<>(subFlows);
+
+        for (AuthenticationFlowRepresentation subflow : subFlows) {
+            allSubFlows.addAll(getAllSubFlows(realmImport, subflow));
+        }
+
+        return allSubFlows;
     }
 
     private boolean isSubFlowNotExistingOrHasToBeUpdated(

--- a/src/test/java/de/adorsys/keycloak/config/service/ImportAuthenticationFlowsIT.java
+++ b/src/test/java/de/adorsys/keycloak/config/service/ImportAuthenticationFlowsIT.java
@@ -1133,6 +1133,20 @@ class ImportAuthenticationFlowsIT extends AbstractImportIT {
         assertThat(thrown.getMessage(), is("Execution property authenticator 'registration-page-form' can be only set if the sub-flow 'JToken Conditional' type is 'form-flow'."));
     }
 
+    @Test
+    void shouldChangeSubFlowOfFirstBrokerLoginFlow() throws IOException {
+        doImport("init_custom_first-broker-login-flow.json");
+        doImport("updated_custom_first-broker-login-flow.json");
+
+        RealmRepresentation realm = keycloakProvider.getInstance().realm(REALM_NAME).partialExport(true, true);
+        AuthenticationFlowRepresentation flow = getAuthenticationFlow(realm, "my-first-broker-login-handle-existing-account");
+
+        assertThat(realm.getRealm(), is(REALM_NAME));
+        assertThat(realm.isEnabled(), is(true));
+
+        assertThat(flow.getAuthenticationExecutions().get(1).getRequirement(), is("DISABLED"));
+    }
+
     private List<AuthenticationExecutionExportRepresentation> getExecutionFromFlow(AuthenticationFlowRepresentation flow, String executionAuthenticator) {
         List<AuthenticationExecutionExportRepresentation> executions = flow.getAuthenticationExecutions();
 

--- a/src/test/resources/import-files/auth-flows/init_custom_first-broker-login-flow.json
+++ b/src/test/resources/import-files/auth-flows/init_custom_first-broker-login-flow.json
@@ -1,0 +1,102 @@
+{
+  "enabled": true,
+  "realm": "realmWithFlow",
+  "authenticationFlows": [
+    {
+      "alias": "my-first-broker-login-handle-existing-account",
+      "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-auto-link",
+          "requirement": "REQUIRED",
+          "priority": 0,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "idp-confirm-link",
+          "requirement": "REQUIRED",
+          "priority": 1,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "alias": "my-first-broker-login-user-creation-or-linking",
+      "description": "Flow for the existing/non-existing user alternatives",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-create-user-if-unique",
+          "requirement": "ALTERNATIVE",
+          "priority": 0,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "ALTERNATIVE",
+          "priority": 1,
+          "flowAlias": "my-first-broker-login-handle-existing-account",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "alias": "my-first-broker-login",
+      "description": "custom changed first broker login",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-review-profile",
+          "requirement": "DISABLED",
+          "priority": 0,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "DISABLED",
+          "priority": 1,
+          "flowAlias": "my-first-broker-login-user-creation-or-linking",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    }
+  ],
+  "identityProviders": [
+    {
+      "alias": "keycloak-oidc",
+      "displayName": "my-keycloak-oidc",
+      "providerId": "keycloak-oidc",
+      "enabled": true,
+      "trustEmail": true,
+      "storeToken": false,
+      "addReadTokenRoleOnCreate": false,
+      "authenticateByDefault": false,
+      "linkOnly": false,
+      "firstBrokerLoginFlowAlias": "my-first-broker-login",
+      "config": {
+        "clientId": "example-client-id",
+        "tokenUrl": "https://example.com/protocol/openid-connect/token",
+        "authorizationUrl": "https://example.com/protocol/openid-connect/auth",
+        "clientAuthMethod": "client_secret_post",
+        "logoutUrl": "https://example.com/protocol/openid-connect/logout",
+        "syncMode": "FORCE",
+        "clientSecret": "example-client-secret",
+        "backchannelSupported": "true",
+        "defaultScope": "",
+        "guiOrder": "0",
+        "useJwksUrl": "true"
+      }
+    }
+  ]
+}

--- a/src/test/resources/import-files/auth-flows/updated_custom_first-broker-login-flow.json
+++ b/src/test/resources/import-files/auth-flows/updated_custom_first-broker-login-flow.json
@@ -1,0 +1,102 @@
+{
+  "enabled": true,
+  "realm": "realmWithFlow",
+  "authenticationFlows": [
+    {
+      "alias": "my-first-broker-login-handle-existing-account",
+      "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-auto-link",
+          "requirement": "REQUIRED",
+          "priority": 0,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "idp-confirm-link",
+          "requirement": "DISABLED",
+          "priority": 1,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "alias": "my-first-broker-login-user-creation-or-linking",
+      "description": "Flow for the existing/non-existing user alternatives",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-create-user-if-unique",
+          "requirement": "ALTERNATIVE",
+          "priority": 0,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "ALTERNATIVE",
+          "priority": 1,
+          "flowAlias": "my-first-broker-login-handle-existing-account",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "alias": "my-first-broker-login",
+      "description": "custom changed first broker login",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-review-profile",
+          "requirement": "DISABLED",
+          "priority": 0,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "DISABLED",
+          "priority": 1,
+          "flowAlias": "my-first-broker-login-user-creation-or-linking",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    }
+  ],
+  "identityProviders": [
+    {
+      "alias": "keycloak-oidc",
+      "displayName": "my-keycloak-oidc",
+      "providerId": "keycloak-oidc",
+      "enabled": true,
+      "trustEmail": true,
+      "storeToken": false,
+      "addReadTokenRoleOnCreate": false,
+      "authenticateByDefault": false,
+      "linkOnly": false,
+      "firstBrokerLoginFlowAlias": "my-first-broker-login",
+      "config": {
+        "clientId": "example-client-id",
+        "tokenUrl": "https://example.com/protocol/openid-connect/token",
+        "authorizationUrl": "https://example.com/protocol/openid-connect/auth",
+        "clientAuthMethod": "client_secret_post",
+        "logoutUrl": "https://example.com/protocol/openid-connect/logout",
+        "syncMode": "FORCE",
+        "clientSecret": "example-client-secret",
+        "backchannelSupported": "true",
+        "defaultScope": "",
+        "guiOrder": "0",
+        "useJwksUrl": "true"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Sometimes changes in authentication subflows (e.g. through importing a new file) are not considered as a change. Hence no update occurs. This is because not all authentication subflows are considered in `hasAnySubFlowToBeUpdated`.
An example can be found in the added test. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
tbd

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
